### PR TITLE
登録ウイスキー検索機能実装

### DIFF
--- a/src/main/java/com/whisukiquest/whiskyquest_api/ServletInitializer.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/ServletInitializer.java
@@ -7,7 +7,7 @@ public class ServletInitializer extends SpringBootServletInitializer {
 
 	@Override
 	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-		return application.sources(WhiskyquestApiApplication.class);
+		return application.sources(WhiskyQuestApiApplication.class);
 	}
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/WhiskyQuestApiApplication.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/WhiskyQuestApiApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class WhiskyquestApiApplication {
+public class WhiskyQuestApiApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(WhiskyquestApiApplication.class, args);
+		SpringApplication.run(WhiskyQuestApiApplication.class, args);
 	}
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
@@ -1,5 +1,29 @@
 package com.whisukiquest.whiskyquest_api.controller;
 
+import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
+import com.whisukiquest.whiskyquest_api.service.WhiskyService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
 public class WhiskyController {
+
+private final WhiskyService service;
+
+@Autowired
+public WhiskyController(WhiskyService service){
+  this.service = service;
+}
+
+@GetMapping("/whisky/{userId}")
+  public List<WhiskyDetail> getWhiskyList(
+      @PathVariable  int userId){
+   return service.searchWhisky(userId);
+  }
+
+
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/data/Rating.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/data/Rating.java
@@ -1,5 +1,18 @@
 package com.whisukiquest.whiskyquest_api.data;
 
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
 public class Rating {
+
+  private int id;
+  private int userId;
+  private int whiskyId;
+  private int rating;
+  private LocalDateTime ratingAt;
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/data/Users.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/data/Users.java
@@ -1,5 +1,15 @@
 package com.whisukiquest.whiskyquest_api.data;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class Users {
+
+  private int id;
+  private String userName;
+  private String mail;
+  private String password;
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/data/Whisky.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/data/Whisky.java
@@ -1,5 +1,20 @@
 package com.whisukiquest.whiskyquest_api.data;
 
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class Whisky {
+
+  private int id;
+  private  int userId;
+  private String name;
+  private String taste;
+  private String drinkingStyle;
+  private int price;
+  private String memo;
+  private boolean isDeleted;
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/domain/WhiskyDetail.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/domain/WhiskyDetail.java
@@ -1,0 +1,18 @@
+package com.whisukiquest.whiskyquest_api.domain;
+
+import com.whisukiquest.whiskyquest_api.data.Rating;
+import com.whisukiquest.whiskyquest_api.data.Users;
+import com.whisukiquest.whiskyquest_api.data.Whisky;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WhiskyDetail {
+
+  private Users users;
+  private List<Whisky> whiskyList;
+  private List<Rating> ratingList;
+
+}

--- a/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
@@ -1,5 +1,14 @@
 package com.whisukiquest.whiskyquest_api.repository;
 
-public class WhiskyRepository {
+import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface WhiskyRepository {
+
+  //userId検索してWhisky情報とrating情報が全件取れてくる
+  List<WhiskyDetail> searchWhisky (int userId);
+
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
@@ -1,5 +1,23 @@
 package com.whisukiquest.whiskyquest_api.service;
 
+import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
+import com.whisukiquest.whiskyquest_api.repository.WhiskyRepository;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
 public class WhiskyService {
+
+private final WhiskyRepository repository;
+
+@Autowired
+public WhiskyService(WhiskyRepository repository){
+this.repository = repository;
+}
+public List<WhiskyDetail>searchWhisky(int userId){
+return repository.searchWhisky(userId);
+}
+
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=whiskyquest-api
+
+spring.datasource.url=jdbc:mysql://localhost:3306/whisukiquest
+spring.datasource.username=root
+spring.datasource.password=kooking3822
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+#MyBatis
+mybatis.configuration.map-underscore-to-camel-case=true
+mybatis.mapper-locations=classpath*:/mapper/*.xml
+

--- a/src/main/resources/mapper/whiskyRepository.xml
+++ b/src/main/resources/mapper/whiskyRepository.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.whisukiquest.whiskyquest_api.repository.WhiskyRepository">
+
+<!--UserIdに紐づくWhisky情報検索-->
+  <select id="searchWhisky" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
+    SELECT * FROM whisky WHERE user_id= #{userId}
+  </select>
+
+</mapper>
+

--- a/src/test/java/com/whisukiquest/whiskyquest_api/WhiskyQuestApiApplicationTests.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/WhiskyQuestApiApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class WhiskyquestApiApplicationTests {
+class WhiskyQuestApiApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION

## 実装内容
- ユーザーIDに紐づくウイスキー情報の検索機能追加
- WhiskyDetailクラス追加
　1ユーザー：複数ウイスキー情報：複数評価　の為whiskyとratingはListにしました。
-DB修正
　whisky(userId)、rating(userId/whiskyId)に外部キー設定
　併せてCASCADEも設定しました。


## 動作確認
### ポストマン
<img width="1263" height="914" alt="スクリーンショット 2025-08-17 150006" src="https://github.com/user-attachments/assets/e2a9f9e9-fdae-4d0f-8d5e-b30cdbd15924" />

## 工夫した点・学んだこと
- ratingはwhiskyに持たせようか悩みましたが、評価ランキング機能を追加させたいため、
　別々で管理することにしました。
　まだ、converterが作れていないので、whiskyDetailをリターンしていますが、
　ウイスキー情報しかとれていません。