### PR TITLE
新規登録機能、テスト実装

### DIFF
--- a/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
@@ -52,4 +52,48 @@ public class WhiskyRepositoryTest {
     assertThat(actual.size()).isEqualTo(1);
   }
 
+  @Test  //registerUser
+  void ユーザー情報の新規登録が出来る事() {
+    Users user = new Users();
+    user.setUserName("高橋　杏里");
+    user.setMail("anri@gmail.com");
+    user.setPassword("qwe1");
+
+    sut.registerUser(user);
+    Users actual = sut.searchUserById(user.getId());
+
+    assertThat(actual).isEqualTo(user);
+
+  }
+
+  @Test   //registerWhisky
+  void ウイスキー情報の新規登録が出来る事() {
+    Whisky whisky = new Whisky();
+    whisky.setName("メーカーズマーク");
+    whisky.setTaste("甘い");
+    whisky.setDrinkingStyle("ハイボール");
+    whisky.setPrice(3000);
+    whisky.setMemo("ボトルもかわいい");
+
+    sut.registerWhisky(whisky);
+    Whisky actual = sut.searchWhisky(whisky.getId());
+
+    assertThat(actual).isEqualTo(whisky);
+  }
+
+  @Test   //registerRating
+  void 評価情報の新規登録が出来る事() {
+    Rating rating = new Rating();
+    rating.setRating(5);
+    rating.setUserId(2);
+    rating.setWhiskyId(2);
+
+    sut.registerRating(rating);
+    List<Rating> actual = sut.searchRatingList(rating.getUserId());
+    //rating.getUserId()としているので、rating全件ではなく上記でsetしてるuserId(2)のratingを
+    //取得してactualに代入してる
+    assertThat(actual.size()).isEqualTo(3);
+    //なのでサイズで「全件＋今追加した分」のisEqualTo(11)じゃなくて、isEqualTo(3)になる
+
+  }
 }

--- a/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
@@ -9,6 +9,7 @@ import com.whisukiquest.whiskyquest_api.data.Users;
 import com.whisukiquest.whiskyquest_api.data.Whisky;
 import com.whisukiquest.whiskyquest_api.domain.UserDetail;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
+import com.whisukiquest.whiskyquest_api.domain.WhiskyInfo;
 import com.whisukiquest.whiskyquest_api.repository.WhiskyRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,5 +86,33 @@ public class WhiskyServiceTest {
     verify(converter, times(1)).converterWhiskyDetail(whisky, ratingList);
 
     assertEquals(expected, actual);
+  }
+
+  @Test //registerUsers
+  void ユーザーの新規登録＿適切にリポジトリが呼び出せてること(){
+    int id = 999;
+    Users users = new Users();
+    users.setId(id);
+    sut.registerUsers(users);
+
+   verify(repository,times(1)).registerUser(users);
+  }
+
+  @Test //registerWhiskyInfo
+  void ウイスキー情報と評価情報の登録＿適切にリポジトリが呼び出せている事(){
+    int id = 999;
+    Whisky whisky = new Whisky();
+    whisky.setId(id);
+    Rating rating = new Rating();
+    rating.setId(id);
+    WhiskyInfo whiskyInfo = new WhiskyInfo();
+    whiskyInfo.setWhisky(whisky);
+    whiskyInfo.setRating(rating);
+
+    sut.registerWhiskyInfo(whiskyInfo);
+
+    verify(repository,times(1)).registerWhisky(whisky);
+    verify(repository,times(1)).registerRating(rating);
+
   }
 }


### PR DESCRIPTION
## 実装内容
-新規登録のテストをservice、controller、repositoryに実装しました。

## テスト結果
### controller
<img width="1330" height="663" alt="スクリーンショット 2025-08-23 101911" src="https://github.com/user-attachments/assets/b3643544-72d7-4912-b177-07d85d74190c" />

### service
<img width="1389" height="692" alt="スクリーンショット 2025-08-23 102013" src="https://github.com/user-attachments/assets/7c05bf3a-a37a-4ebf-b21b-8580e7ed33c0" />

### repository
<img width="1107" height="764" alt="スクリーンショット 2025-08-23 101958" src="https://github.com/user-attachments/assets/9c116bff-2c43-446f-994e-25c616a85f1b" />


## 工夫した点・学んだ点
-controller
　Jsonの構造が正しくマッピングされてるか確認する為、serviceをモック化させてjsonPathを使用して
　中身のチェックも行いました。
　Mockito.when(service.registerWhiskyInfo(any(WhiskyInfo.class))).thenReturn(whiskyInfo);
　ここの部分で、registerWhiskyInfoの引数を(whiskyInfo)にしていて、テストに引っかかってしまっていたが
　(whiskyInfo)だと、完全に中身が一致しないとダメな事を知り、
　(any(WhiskyInfo.class))だとWhiskyInfo 型ならどんなインスタンスでもOKだったのでこちらを使用しました。
　