### PR TITLE
更新機能のテスト実装

### DIFF
--- a/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
@@ -56,7 +56,8 @@ public class WhiskyController {
 
   //ユーザー情報の更新
 @PutMapping("/updateUser/{userId}")
-  public ResponseEntity<Users> updateUser(@RequestBody Users users){
+  public ResponseEntity<Users> updateUser(@PathVariable int userId ,
+    @RequestBody Users users){
     Users responseUser = service.updateUser(users);
     return ResponseEntity.ok(responseUser);
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
@@ -41,7 +41,6 @@ public interface WhiskyRepository {
 
   //ウイスキー情報の更新
   void updateWhisky(Whisky whisky);
-
   //評価情報の更新
   void updateRating(Rating rating);
 

--- a/src/test/java/com/whisukiquest/whiskyquest_api/controller/WhiskyControllerTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/controller/WhiskyControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -151,5 +152,74 @@ public class WhiskyControllerTest {
     verify(service, times(1)).registerWhiskyInfo(any());
   }
 
+  @Test //@PutMapping("/updateUser/{userId}")
+  void ユーザー情報の更新ができる事() throws Exception {
+    int userId = 1;
+    Users users = new Users();
+    users.setId(userId);
+    users.setUserName("谷口　雪");
 
+    Mockito.when(service.updateUser(any(Users.class))).thenReturn(users);
+
+    mockMvc.perform(put("/updateUser/{userId}", userId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                      {
+                          "userName": "谷口　雪",
+                          "mail": "aya@example.com",
+                          "password": "asd1"
+                      }
+                    """
+            ))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userName").value("谷口　雪"));
+    verify(service, times(1)).updateUser(any(Users.class));
+  }
+
+  @Test //@PutMapping("/updateWhiskyInfo/{WhiskyId}/{RatingId}")
+  void ウイスキー情報と評価情報の更新() throws Exception {
+    int whiskyId = 1;
+    int ratingId = 1;
+
+    Whisky whisky = new Whisky();
+    whisky.setId(whiskyId);
+    whisky.setName("山崎12年");
+
+    Rating rating = new Rating();
+    rating.setId(ratingId);
+    rating.setRating(4);
+
+    WhiskyInfo whiskyInfo = new WhiskyInfo();
+    whiskyInfo.setWhisky(whisky);
+    whiskyInfo.setRating(rating);
+    Mockito.when(service.updateWhiskyInfo(any(WhiskyInfo.class))).thenReturn(whiskyInfo);
+
+    mockMvc.perform(put("/updateWhiskyInfo/{WhiskyId}/{RatingId}", whiskyId, ratingId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                """
+                    {
+                        "whisky": {
+                            "userId":1,
+                            "name": "メーカーズマーク",
+                            "taste": "甘い",
+                            "drinkingStyle": "ハイボール",
+                            "price": 3000,
+                            "memo": "ボトルもかわいい",
+                            "deleted": false
+                        },
+                        "rating": {
+                            "userId": 1,
+                            "whiskyId" :1,
+                            "rating": 5
+                        }
+                    }
+                    """
+            ))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.whisky.name").value("山崎12年"));
+    verify(service, times(1)).updateWhiskyInfo(any(WhiskyInfo.class));
+
+  }
 }

--- a/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
@@ -17,42 +17,43 @@ public class WhiskyRepositoryTest {
   private WhiskyRepository sut;
 
 
-  @Test
-    //searchUserById
-  void ユーザーの詳細検索が出来る事() {
+  @Test//searchUserById
+  void ユーザーの詳細１件の検索が出来る事() {
     Users actual = sut.searchUserById(1);
     assertThat(actual.getId()).isEqualTo(1);
   }
 
-  @Test
-    //searchWhiskyList
+  @Test//searchWhiskyList
   void ウイスキー情報一覧の検索が出る事() {
     List<Whisky> actual = sut.searchWhiskyList(1);
     assertThat(actual.size()).isEqualTo(2);
   }
 
-  @Test
-    //searchRatingList
+  @Test//searchWhiskyById
+  void ウイスキー情報1件の検索が出来る事() {
+    Whisky actual = sut.searchWhiskyById(1);
+    assertThat(actual.getId()).isEqualTo(1);
+  }
+
+  @Test//searchRatingList
   void 評価情報一覧が検索出来る事() {
     List<Rating> actual = sut.searchRatingList(1);
     assertThat(actual.size()).isEqualTo(2);
   }
 
-  @Test
-    //searchWhisky
-  void ウイスキーIDでウイスキー情報が検索出来る事() {
-    Whisky actual = sut.searchWhiskyById(1);
-    assertThat(actual.getId()).isEqualTo(1);
-  }
-
-  @Test
-    //searchRatingByWhiskyId
+  @Test//searchRatingByWhiskyId
   void ウイスキーIDで評価情報が検索出来る事() {
     List<Rating> actual = sut.searchRatingByWhiskyId(1);
     assertThat(actual.size()).isEqualTo(1);
   }
 
-  @Test  //registerUser
+  @Test//searchRatingById
+  void 評価情報1件の検索が出来る事() {
+    Rating actual = sut.searchRatingById(1);
+    assertThat(actual.getId()).isEqualTo(1);
+  }
+
+  @Test//registerUser
   void ユーザー情報の新規登録が出来る事() {
     Users user = new Users();
     user.setUserName("高橋　杏里");
@@ -66,7 +67,7 @@ public class WhiskyRepositoryTest {
 
   }
 
-  @Test   //registerWhisky
+  @Test//registerWhisky
   void ウイスキー情報の新規登録が出来る事() {
     Whisky whisky = new Whisky();
     whisky.setName("メーカーズマーク");
@@ -81,7 +82,7 @@ public class WhiskyRepositoryTest {
     assertThat(actual).isEqualTo(whisky);
   }
 
-  @Test   //registerRating
+  @Test//registerRating
   void 評価情報の新規登録が出来る事() {
     Rating rating = new Rating();
     rating.setRating(5);
@@ -96,4 +97,52 @@ public class WhiskyRepositoryTest {
     //なのでサイズで「全件＋今追加した分」のisEqualTo(11)じゃなくて、isEqualTo(3)になる
 
   }
+
+  @Test// updateUser
+  void ユーザーIDでユーザー情報の更新が出来る事() {
+    Users users = new Users();
+    users.setId(1);
+    users.setUserName("山田　陽介");
+    users.setMail("taro@example.com");
+    users.setPassword("pass1234");
+
+    sut.updateUser(users);
+    Users actual = sut.searchUserById(1);
+
+    assertThat(actual).isEqualTo(users);
+  }
+
+  @Test//updateWhisky
+  void ウイスキー情報の更新が出来る事() {
+    Whisky whisky = new Whisky();
+    whisky.setId(1);
+    whisky.setName("山崎12年");
+    whisky.setTaste("フルーティーで華やか");
+    whisky.setDrinkingStyle("ストレート、ハイボール");
+    whisky.setPrice(12000);
+    whisky.setMemo("銀座のバーで初めて飲んだ。香りが素晴らしい");
+
+    sut.updateWhisky(whisky);
+    Whisky actual = sut.searchWhiskyById(1);
+
+    assertThat(actual).isEqualTo(whisky);
+
+  }
+
+  @Test//updateRating
+  void 評価情報の更新が出来る事() {
+    Rating rating = new Rating();
+    rating.setId(1);
+    rating.setUserId(1);
+    rating.setWhiskyId(1);
+    rating.setRating(4);
+
+    sut.updateRating(rating);
+    Rating actual = sut.searchRatingById(1);
+
+    assertThat(actual.getId()).isEqualTo(rating.getId());
+    assertThat(actual.getRating()).isEqualTo(rating.getRating());
+  }
+
+
 }

--- a/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 public class WhiskyServiceTest {
@@ -114,5 +115,41 @@ public class WhiskyServiceTest {
     verify(repository,times(1)).registerWhisky(whisky);
     verify(repository,times(1)).registerRating(rating);
 
+  }
+
+  @Test //updateUser
+  void ユーザー情報の更新＿適切にリポジトリが呼び出されている事(){
+    Users users = new Users();
+    users.setId(1);
+    users.setUserName("山田　太郎");
+    sut.updateUser(users);
+
+    Mockito.when(repository.searchUserById(1)).thenReturn(users);
+    Users actual = repository.searchUserById(1);
+
+    verify(repository, times(1)).updateUser(users);
+    assertEquals(users.getId(), actual.getId());
+    assertEquals(users.getUserName(), actual.getUserName());
+  }
+
+  @Transactional
+  @Test //updateWhiskyInfo
+  void ウイスキー情報と評価情報の更新_リポジトリが適切に呼び出されている事() {
+    Whisky whisky = new Whisky();
+    whisky.setId(1);
+    Rating rating = new Rating();
+    rating.setId(1);
+    WhiskyInfo whiskyInfo = new WhiskyInfo();
+    whiskyInfo.setWhisky(whisky);
+    whiskyInfo.setRating(rating);
+    Mockito.when(repository.searchWhiskyById(1)).thenReturn(whisky);
+    Mockito.when(repository.searchRatingById(1)).thenReturn(rating);
+
+    WhiskyInfo actual = sut.updateWhiskyInfo(whiskyInfo);
+
+    verify(repository, times(1)).updateWhisky(whisky);
+    verify(repository, times(1)).updateRating(rating);
+    assertEquals(actual.getWhisky().getId(), whisky.getId());
+    assertEquals(actual.getRating().getId(), rating.getId());
   }
 }


### PR DESCRIPTION
## 実装内容
-repositoryテスト
ユーザー情報、ウイスキー情報は中身の比較
評価情報のみ、LocalDateTimeを使用している為条件指定して比較しました。

## テスト結果
### controller
<img width="1441" height="747" alt="スクリーンショット 2025-08-27 165927" src="https://github.com/user-attachments/assets/6e26dc93-9b0f-4b28-b2b2-c9e94a174a13" />

### service
<img width="1425" height="752" alt="スクリーンショット 2025-08-27 165959" src="https://github.com/user-attachments/assets/1df95711-8092-481d-8cfa-492dd2152044" />

### repository
<img width="1418" height="739" alt="スクリーンショット 2025-08-27 170018" src="https://github.com/user-attachments/assets/8c841be8-8e54-46c0-bbf2-6fc9e820045f" />


