### PR TITLE
論理削除の実装

### DIFF
--- a/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
@@ -71,5 +71,30 @@ public class WhiskyController {
     return ResponseEntity.ok(responseWhiskyInfo);
   }
 
+  //ユーザー情報の論理削除
+  @PutMapping("/deleteUser/{userId}")
+  public ResponseEntity<Void> deleteUser(@PathVariable int userId) {
+    service.deleteUser(userId);
+    return ResponseEntity.ok().build();
+  }
+
+  //ウイスキー情報の論理削除
+  @PutMapping("/deleteWhisky/{userId}")
+  public ResponseEntity<Void> deleteWhisky(@PathVariable int userId) {
+    service.deleteWhisky(userId);
+    return ResponseEntity.ok().build();
+  }
+
+  //評価情報の論理削除
+  @PutMapping("/deleteRating/{userId}")
+  public ResponseEntity<Void> deleteRating(@PathVariable int userId) {
+    service.deleteRating(userId);
+    return ResponseEntity.ok().build();
+  }
+
+
 }
+
+
+
 

--- a/src/main/java/com/whisukiquest/whiskyquest_api/data/Rating.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/data/Rating.java
@@ -15,5 +15,5 @@ public class Rating {
   private int whiskyId;
   private int rating;
   private LocalDateTime ratingAt;
-
+  private boolean isDeleted;
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/data/Users.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/data/Users.java
@@ -13,5 +13,6 @@ public class Users {
   private String userName;
   private String mail;
   private String password;
+  private boolean isDeleted;
 
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
@@ -44,5 +44,12 @@ public interface WhiskyRepository {
   //評価情報の更新
   void updateRating(Rating rating);
 
+  //ユーザー情報の論理削除
+  void deleteUser(Users users);
 
+  //ウイスキー情報の論理削除
+  void deleteWhisky(Whisky whisky);
+
+  //評価情報の論理削除
+  void deleteRating(Rating rating);
 }

--- a/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
@@ -81,4 +81,25 @@ public class WhiskyService {
     updateInfo.setRating(rating);
     return updateInfo;
   }
+
+  //ユーザー情報の論理削除
+  public void deleteUser(int id){
+    Users user = new Users();
+    user.setId(id);
+    repository.deleteUser(user);
+  }
+
+  //ウイスキー情報の論理削除
+  public void deleteWhisky(int userId){
+    Whisky whisky = new Whisky();
+    whisky.setUserId(userId);
+    repository.deleteWhisky(whisky);
+  }
+
+  //評価情報の論理削除
+  public void deleteRating(int userId){
+    Rating rating = new Rating();
+    rating.setUserId(userId);
+    repository.deleteRating(rating);
+  }
 }

--- a/src/main/resources/mapper/whiskyRepository.xml
+++ b/src/main/resources/mapper/whiskyRepository.xml
@@ -6,32 +6,32 @@
 
   <!--User情報検索-->
   <select id="searchUserById" resultType="com.whisukiquest.whiskyquest_api.data.Users">
-    SELECT * FROM users WHERE id= #{Id}
+    SELECT * FROM users WHERE id= #{Id} AND is_deleted = FALSE
   </select>
 
   <!--Whisky情報検索-->
   <select id="searchWhiskyList" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
-    SELECT * FROM whisky WHERE user_id= #{userId}
+    SELECT * FROM whisky WHERE user_id= #{userId} AND is_deleted = FALSE
   </select>
 
   <!--Whisky詳細検索、whiskyIdで検索-->
   <select id="searchWhiskyById" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
-    SELECT * FROM whisky WHERE id= #{Id}
+    SELECT * FROM whisky WHERE id= #{Id} AND is_deleted = FALSE
   </select>
 
   <!--Rating情報検索-->
   <select id="searchRatingList" resultType="com.whisukiquest.whiskyquest_api.data.Rating">
-    SELECT * FROM rating WHERE user_id= #{userId}
+    SELECT * FROM rating WHERE user_id= #{userId} AND is_deleted = FALSE
   </select>
 
   <!--Rating一覧検索、whiskyIdで検索-->
   <select id="searchRatingByWhiskyId" resultType="com.whisukiquest.whiskyquest_api.data.Rating">
-    SELECT * FROM rating WHERE whisky_id= #{whiskyId}
+    SELECT * FROM rating WHERE whisky_id= #{whiskyId} AND is_deleted = FALSE
   </select>
 
   <!--Rating１件の検索　ratingIdで検索-->
   <select id="searchRatingById" resultType="com.whisukiquest.whiskyquest_api.data.Rating">
-    SELECT * FROM rating WHERE id = #{ratingId}
+    SELECT * FROM rating WHERE id = #{ratingId} AND is_deleted = FALSE
   </select>
 
   <!--ユーザー情報の新規登録-->
@@ -70,5 +70,22 @@
     UPDATE rating SET user_id = #{userId} , whisky_id = #{whiskyId} , rating = #{rating}
     WHERE id = #{id}
   </update>
+
+  <!--ユーザー情報の論理削除-->
+  <update id="deleteUser">
+    UPDATE users SET is_deleted = TRUE WHERE id = #{id}
+  </update>
+
+  <!--ウイスキー情報の論理削除-->
+  <update id="deleteWhisky">
+    UPDATE whisky SET is_deleted = TRUE WHERE user_id = #{userId}
+  </update>
+
+  <!--評価情報の論理削除-->
+  <update id="deleteRating">
+    UPDATE rating SET is_deleted = TRUE WHERE user_id = #{userId}
+  </update>
+
+
 </mapper>
 


### PR DESCRIPTION
## 実装内容
-ユーザー情報、ウイスキー情報、評価情報の論理削除
　
-外部キーにCASCADEを設定していましたが、CASCADEは物理削除をしてしまう事を知り
　設定を外して処理を進めました。

-ユーザー情報と評価情報にisDeletedを追加

-XML
　各検索項目にAND is_deleted = FALSEを追加
　削除された項目は表示されないようにしました。

-エンティティ
 各エンティティにprivate boolean isDeleted;を追加

## 実装結果
### ユーザー削除
<img width="1267" height="562" alt="スクリーンショット 2025-08-27 195924" src="https://github.com/user-attachments/assets/bce425eb-0bbc-46a7-ac23-1aaa257a8f61" />
<img width="878" height="238" alt="スクリーンショット 2025-08-27 201213" src="https://github.com/user-attachments/assets/74b03a67-25f8-40f1-9bda-5d63bebda1e4" />

### ウイスキー情報
<img width="1236" height="506" alt="スクリーンショット 2025-08-27 195913" src="https://github.com/user-attachments/assets/70a64dc2-1eaa-4934-8dae-bd48f762707e" />
<img width="1828" height="341" alt="スクリーンショット 2025-08-27 201226" src="https://github.com/user-attachments/assets/e995c8da-e28b-4edd-b6f9-4386ed0725e5" />

### 評価情報
<img width="1272" height="534" alt="スクリーンショット 2025-08-27 200002" src="https://github.com/user-attachments/assets/c356905d-6982-45a1-8113-6edba86222ab" />
<img width="809" height="337" alt="スクリーンショット 2025-08-27 201234" src="https://github.com/user-attachments/assets/f2d14ad4-78d7-4195-91f9-91567ba742cf" />


## 学んだ事
CASCADEを設定したまま論理削除の処理を追加して進めようか悩みましたが
誤って物理削除してしまう事も考え、今回の実装にしました。

物理削除と論理削除は実装方法や意識しないといけない部分も違うため
慎重に進める必要があると感じました。
後々は、論理削除したデータはずっとDBに残しておかず、一定の期間が過ぎたら削除する
実装をしてみたいと思います。