### PR TITLE
論理削除のテスト実装

### DIFF
--- a/src/test/java/com/whisukiquest/whiskyquest_api/controller/WhiskyControllerTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/controller/WhiskyControllerTest.java
@@ -222,4 +222,35 @@ public class WhiskyControllerTest {
     verify(service, times(1)).updateWhiskyInfo(any(WhiskyInfo.class));
 
   }
+
+  @Test //@PutMapping("/deleteUser/{userId}")
+  void ユーザー情報の論理削除が出来ること() throws Exception {
+    int userId = 999;
+
+    mockMvc.perform(put("/deleteUser/{userId}", userId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).deleteUser(userId);
+  }
+
+  @Test//@PutMapping("/deleteWhisky/{userId}")
+  void ウイスキー情報の論理削除ができること() throws Exception {
+    int userId = 999;
+
+    mockMvc.perform(put("/deleteWhisky/{userId}", userId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).deleteWhisky(userId);
+
+  }
+
+  @Test// @PutMapping("/deleteRating/{userId}")
+  void 評価情報の論理削除ができること() throws Exception {
+    int userId = 999;
+    mockMvc.perform(put("/deleteRating/{userId}", userId))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).deleteRating(userId);
+
+  }
 }

--- a/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.whisukiquest.whiskyquest_api.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.whisukiquest.whiskyquest_api.data.Rating;
 import com.whisukiquest.whiskyquest_api.data.Users;
@@ -144,5 +145,39 @@ public class WhiskyRepositoryTest {
     assertThat(actual.getRating()).isEqualTo(rating.getRating());
   }
 
+  @Test //deleteUser
+  void ユーザー情報が論理削除出来ること() {
+    int id = 2;
+    Users user = new Users();
+    user.setId(id);
 
+    sut.deleteUser(user);
+    assertNull(sut.searchUserById(id), "論理削除されたユーザーは検索出来ない事");
+  }
+
+  @Test //deleteWhisky
+  void ウイスキー情報が論理削除出来ること(){
+    int id = 2;
+    int userId = 2;
+    Whisky whisky = new Whisky();
+    whisky.setId(id);
+    whisky.setUserId(userId);
+
+    sut.deleteWhisky(whisky);
+    assertNull(sut.searchWhiskyById(id), "論理削除されたウイスキー情報は検索出来ない事");
+
+  }
+
+  @Test //deleteRating
+  void 評価情報が論理削除出来ること() {
+    int id = 2;
+    int userId = 2;
+    Rating rating = new Rating();
+    rating.setId(id);
+    rating.setUserId(userId);
+
+    sut.deleteRating(rating);
+    assertNull(sut.searchRatingById(id), "論理削除されている評価情報は検索出来ない事");
+
+  }
 }

--- a/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
+++ b/src/test/java/com/whisukiquest/whiskyquest_api/service/WhiskyServiceTest.java
@@ -3,6 +3,7 @@ package com.whisukiquest.whiskyquest_api.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 import com.whisukiquest.whiskyquest_api.controller.converter.WhiskyConverter;
 import com.whisukiquest.whiskyquest_api.data.Rating;
 import com.whisukiquest.whiskyquest_api.data.Users;
@@ -151,5 +152,36 @@ public class WhiskyServiceTest {
     verify(repository, times(1)).updateRating(rating);
     assertEquals(actual.getWhisky().getId(), whisky.getId());
     assertEquals(actual.getRating().getId(), rating.getId());
+  }
+
+  @Test //deleteUser
+  void ユーザー情報の倫理削除が出来る事＿適切にリポジトリが呼び出せている事() {
+    int id = 999;
+    Users user = new Users();
+    user.setId(id);
+    sut.deleteUser(id);
+
+    verify(repository, times(1)).deleteUser(user);
+
+  }
+
+  @Test //deleteWhisky
+  void ウイスキー情報の論理削除が出来る事＿適切にリポジトリが呼び出されている事() {
+    int userId = 999;
+    Whisky whisky = new Whisky();
+    whisky.setUserId(userId);
+    sut.deleteWhisky(userId);
+
+    verify(repository, times(1)).deleteWhisky(whisky);
+  }
+
+  @Test //deleteRating
+  void 評価情報の論理削除が出来る事＿適切にリポジトリが呼び出せている事(){
+    int useId = 999;
+    Rating rating = new Rating();
+    rating.setUserId(useId);
+    sut.deleteRating(useId);
+
+    verify(repository, times(1)).deleteRating(rating);
   }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,9 +1,9 @@
-INSERT INTO users (user_name, mail, password) VALUES
-('山田 太郎', 'taro@example.com', 'pass1234'),
-('鈴木 花子', 'hanako@example.com', 'secure5678'),
-('田中 健二', 'kenji@example.com', 'mypassword'),
-('小林 由紀', 'yuki@example.com', 'abc12345'),
-('伊藤 聡', 'satoshi@example.com', 'qwerty987');
+INSERT INTO users (user_name, mail, password, is_deleted) VALUES
+('山田 太郎', 'taro@example.com', 'pass1234', false),
+('鈴木 花子', 'hanako@example.com', 'secure5678', false),
+('田中 健二', 'kenji@example.com', 'mypassword', false),
+('小林 由紀', 'yuki@example.com', 'abc12345', false),
+('伊藤 聡', 'satoshi@example.com', 'qwerty987', false);
 
 INSERT INTO Whisky (user_id, name, taste, drinking_style, price, memo, is_deleted) VALUES
 (1, '山崎12年', 'フルーティーで華やか', 'ストレート', 12000, '銀座のバーで初めて飲んだ。香りが素晴らしい。', false),
@@ -18,14 +18,14 @@ INSERT INTO Whisky (user_id, name, taste, drinking_style, price, memo, is_delete
 (5, '知多', '軽やかで穏やか', '水割り', 4000, '居酒屋でよく頼む定番。食事に合う。', false);
 
 
-INSERT INTO Rating (user_id, whisky_id, rating) VALUES
-(1, 1, 5),
-(2, 2, 4),
-(3, 3, 5),
-(4, 4, 4),
-(5, 5, 3),
-(1, 6, 5),
-(2, 7, 4),
-(3, 8, 5),
-(4, 9, 4),
-(5, 10, 3);
+INSERT INTO Rating (user_id, whisky_id, rating,is_deleted) VALUES
+(1, 1, 5, false),
+(2, 2, 4, false),
+(3, 3, 5, false),
+(4, 4, 4, false),
+(5, 5, 3, false),
+(1, 6, 5, false),
+(2, 7, 4, false),
+(3, 8, 5, false),
+(4, 9, 4, false),
+(5, 10, 3, false);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -2,7 +2,8 @@ CREATE TABLE users (
     id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     user_name VARCHAR(100) NOT NULL,
     mail VARCHAR(100) NOT NULL,
-    password VARCHAR(100) NOT NULL
+    password VARCHAR(100) NOT NULL,
+    is_deleted BOOLEAN DEFAULT FALSE
 );
 
 CREATE TABLE Whisky (
@@ -13,7 +14,7 @@ CREATE TABLE Whisky (
     drinking_style VARCHAR(100),
     price INT,
     memo TEXT,
-    is_deleted BOOLEAN
+    is_deleted BOOLEAN DEFAULT FALSE
 );
 
 CREATE TABLE Rating (
@@ -21,5 +22,6 @@ CREATE TABLE Rating (
     user_id INT NOT NULL,
     whisky_id INT NOT NULL,
     rating INT,
-    rating_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    rating_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_deleted BOOLEAN DEFAULT FALSE
 );


### PR DESCRIPTION
## 実装内容
-論理削除処理のテストを実装しました。
-schemaSQL、dataSQLにisDeletedを追加、デフォルト値にfalseを設定しました。

## 実装結果
## コントローラー
<img width="1513" height="755" alt="スクリーンショット 2025-08-30 102943" src="https://github.com/user-attachments/assets/dc164534-1068-4ad7-9abc-17f19e3eab1f" />

## サービス
<img width="1460" height="749" alt="スクリーンショット 2025-08-30 103004" src="https://github.com/user-attachments/assets/a5e7070f-fedd-432e-9883-b2cae28b9082" />

## リポジトリ
<img width="1513" height="754" alt="スクリーンショット 2025-08-30 103050" src="https://github.com/user-attachments/assets/3eb488d0-2f15-46ac-8070-eeeae2e15001" />
