### PR TITLE
ウイスキーランキング機能の実装

### DIFF
--- a/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/controller/WhiskyController.java
@@ -4,10 +4,12 @@ import com.whisukiquest.whiskyquest_api.data.Users;
 import com.whisukiquest.whiskyquest_api.domain.UserDetail;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyInfo;
+import com.whisukiquest.whiskyquest_api.domain.WhiskyRanking;
 import com.whisukiquest.whiskyquest_api.service.WhiskyService;
 import com.whisukiquest.whiskyquest_api.validation.Update;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +49,16 @@ public class WhiskyController {
   public UserDetail getUserList(
       @PathVariable  int userId) {
     return service.searchUserDetail(userId);
+  }
+
+  /**
+   * ウイスキーランキング検索です。
+   * 登録のあるウイスキー全件と、そのウイスキーに対する評価を降順で取得します。
+   * @return ウイスキー情報全件、評価情報
+   */
+  @GetMapping("/whiskyRanking")
+  public List<WhiskyRanking> whiskyRankings() {
+    return service.searchWhiskyRanking();
   }
 
   /****

--- a/src/main/java/com/whisukiquest/whiskyquest_api/domain/RatingAverage.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/domain/RatingAverage.java
@@ -1,0 +1,27 @@
+package com.whisukiquest.whiskyquest_api.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "SQLから取得した評価の平均値と件数情報")
+@Getter
+@Setter
+@EqualsAndHashCode
+public class RatingAverage {
+
+  @Schema(description = "ウイスキーID")
+  @Valid
+  private int whiskyId;
+
+  @Schema(description = "平均評価")
+  @Valid
+  private double averageRating;
+
+  @Schema(description = "評価件数")
+  @Valid
+  private int ratingCount;
+
+}

--- a/src/main/java/com/whisukiquest/whiskyquest_api/domain/WhiskyRanking.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/domain/WhiskyRanking.java
@@ -1,0 +1,31 @@
+package com.whisukiquest.whiskyquest_api.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "ウイスキーランキング情報")
+@Getter
+@Setter
+@EqualsAndHashCode
+public class WhiskyRanking {
+
+  @Schema(description = "ウイスキーID")
+  @Valid
+  private int whiskyId;
+
+  @Schema(description = "ウイスキー名")
+  @Valid
+  private String name;
+
+  @Schema(description = "平均評価")
+  @Valid
+  private double averageRating;
+
+  @Schema(description = "評価件数")
+  @Valid
+  private int ratingCount;
+
+}

--- a/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
@@ -3,6 +3,7 @@ package com.whisukiquest.whiskyquest_api.repository;
 import com.whisukiquest.whiskyquest_api.data.Rating;
 import com.whisukiquest.whiskyquest_api.data.Users;
 import com.whisukiquest.whiskyquest_api.data.Whisky;
+import com.whisukiquest.whiskyquest_api.domain.RatingAverage;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -20,6 +21,12 @@ public interface WhiskyRepository {
   Users searchUserById(int id);
 
   /**
+   * ウイスキー情報全件検索を行います。
+   * @return ウイスキー情報
+   */
+  List<Whisky> searchWhisky();
+
+  /**
    * ウイスキーの一覧検索を行います。
    * @param userId　ユーザーID
    * @return ユーザーに紐づくウイスキー一覧
@@ -32,6 +39,12 @@ public interface WhiskyRepository {
    * @return ウイスキーIDに紐づくウイスキー情報
    */
   Whisky searchWhiskyById(int whiskyId);
+
+  /**
+   * 評価情報の平均検索を行います。
+   * @return 評価情報
+   */
+  List<RatingAverage> searchAverageRating();
 
   /**
    * 評価情報の一覧検索を行います。

--- a/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
@@ -4,9 +4,11 @@ import com.whisukiquest.whiskyquest_api.controller.converter.WhiskyConverter;
 import com.whisukiquest.whiskyquest_api.data.Rating;
 import com.whisukiquest.whiskyquest_api.data.Users;
 import com.whisukiquest.whiskyquest_api.data.Whisky;
+import com.whisukiquest.whiskyquest_api.domain.RatingAverage;
 import com.whisukiquest.whiskyquest_api.domain.UserDetail;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyDetail;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyInfo;
+import com.whisukiquest.whiskyquest_api.domain.WhiskyRanking;
 import com.whisukiquest.whiskyquest_api.repository.WhiskyRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,21 @@ public class WhiskyService {
     UserDetail userDetail = converter.converterUserDetail(users, whiskyList, ratingList);
 
     return userDetail;
+  }
+
+  /**
+   * ウイスキーランキング検索です。 ウイスキー全件それぞれに紐づく評価情報を取得します。
+   *
+   * @return ウイスキー情報、評価情報
+   */
+  @Transactional
+  public List<WhiskyRanking> searchWhiskyRanking() {
+    List<Whisky> whiskyList = repository.searchWhisky();
+    List<RatingAverage> ratingAverageList = repository.searchAverageRating();
+    List<WhiskyRanking> whiskyRankingList =
+        converter.converterWhiskyRanking(whiskyList, ratingAverageList);
+
+    return whiskyRankingList;
   }
 
   /***

--- a/src/main/resources/mapper/whiskyRepository.xml
+++ b/src/main/resources/mapper/whiskyRepository.xml
@@ -9,6 +9,11 @@
     SELECT * FROM users WHERE id= #{id} AND is_deleted = FALSE
   </select>
 
+  <!--Whisky情報全件検索-->
+  <select id="searchWhisky" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
+    SELECT * FROM whisky WHERE is_deleted = FALSE
+  </select>
+
   <!--Whisky情報検索-->
   <select id="searchWhiskyList" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
     SELECT * FROM whisky WHERE user_id= #{userId} AND is_deleted = FALSE
@@ -17,6 +22,12 @@
   <!--Whisky詳細検索、whiskyIdで検索-->
   <select id="searchWhiskyById" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
     SELECT * FROM whisky WHERE id= #{id} AND is_deleted = FALSE
+  </select>
+
+  <!--Rating情報平均検索-->
+  <select id="searchAverageRating" resultType="com.whisukiquest.whiskyquest_api.domain.RatingAverage">
+    SELECT whisky_id, AVG(rating) AS average_rating, COUNT(*) AS rating_count
+    FROM rating GROUP BY whisky_id
   </select>
 
   <!--Rating情報検索-->


### PR DESCRIPTION
## 実装内容
アプリ内に登録があるウイスキーをランキング形式で表示するための処理を実装しました。

-DTO追加　
●WhiskyRanking
　表示用ランキングDTO
　[ ウイスキーID / ウイスキー名 / 平均評価 / 評価件数 ]
●RatingAverage
　SQLの結果（平均評価、評価件数）を格納するDTO
　[ ウイスキーID / 平均評価 / 評価件数 ]

-XML
 評価の平均と件数を取得するSQLを実装しました。

-converter
　ウイスキー全件に対して紐づく評価情報をマッピングして、WhiskyRankingに変換する処理を実装しました。

## 実行結果　Postman
<img width="1251" height="876" alt="スクリーンショット 2025-09-19 151357" src="https://github.com/user-attachments/assets/0e0462bc-76f4-42d6-b004-a6cad87ea5ff" />

## 工夫したところ、学んだところ
-converter
　ウイスキーID：RatingAverage　のMapを作りネストや検索処理を簡潔にしました。
　評価情報に同じウイスキーIDが複数存在する場合は、重複をチェックし、例外をスロー、
　WhiskyRankingへセットする際、評価や件数無い場合、null を避けて 0 をセットしました。

-DTO
　WhiskyRanking と RankingAverageを１つで対応しようと思いましたが、
　処理をしやすくするために、初めてSQLの結果を入れる用のDTOを作成しました。
　その結果converterでの処理もやりやすく、DTOの使える幅が広がりました。


最初はウイスキー情報と評価情報を全件とってきて、converterでマッピングと平均と件数取得をすべて処理しようと思いましたが、
SQLで平均値や件数を出せる事を思い出し、今回チャレンジしました。

