### PR TITLE
重複チェック機能追加

### DIFF
--- a/ER.md
+++ b/ER.md
@@ -1,0 +1,35 @@
+```mermaid
+erDiagram
+    USERS ||--o{ RATING : posts
+    WHISKY ||--o{ RATING : receives
+    USERS ||--o{ WHISKY : registers
+
+    USERS {
+        int id
+        string userName
+        string mail
+        string password
+        boolean isDeleted
+    }
+
+    WHISKY {
+        int id
+        int userId
+        string name
+        string taste
+        string drinkingStyle
+        int price
+        boolean isDeleted
+    }
+
+    RATING {
+        int id
+        int userId
+        int whiskyId
+        int rating
+        string comment
+        datetime ratingAt
+        boolean isDeleted
+    }
+
+```

--- a/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/repository/WhiskyRepository.java
@@ -5,6 +5,7 @@ import com.whisukiquest.whiskyquest_api.data.Users;
 import com.whisukiquest.whiskyquest_api.data.Whisky;
 import com.whisukiquest.whiskyquest_api.domain.RatingAverage;
 import java.util.List;
+import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -39,6 +40,13 @@ public interface WhiskyRepository {
    * @return ウイスキーIDに紐づくウイスキー情報
    */
   Whisky searchWhiskyById(int whiskyId);
+
+  /**
+   * ウイスキー名でウイスキー情報の検索を行います。
+   * @param name ウイスキー名
+   * @return ウイスキー名に紐づくウイスキー情報
+   */
+  Optional<Whisky> searchWhiskyByName(String name);
 
   /**
    * 評価情報の平均検索を行います。

--- a/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
+++ b/src/main/java/com/whisukiquest/whiskyquest_api/service/WhiskyService.java
@@ -11,6 +11,7 @@ import com.whisukiquest.whiskyquest_api.domain.WhiskyInfo;
 import com.whisukiquest.whiskyquest_api.domain.WhiskyRanking;
 import com.whisukiquest.whiskyquest_api.repository.WhiskyRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,6 +73,15 @@ public class WhiskyService {
     List<Rating> ratingList = repository.searchRatingByWhiskyId(whiskyId);
     WhiskyDetail whiskyDetail = converter.converterWhiskyDetail(whisky, ratingList);
     return whiskyDetail;
+  }
+
+  /***
+   * ウイスキー名でウイスキー情報を検索し、重複がないかチェックします。
+   * @param name ウイスキー名
+   * @return ウイスキー情報
+   */
+  public Optional<Whisky> checkByWhiskyName(String name){
+    return repository.searchWhiskyByName(name);
   }
 
   /****

--- a/src/main/resources/mapper/whiskyRepository.xml
+++ b/src/main/resources/mapper/whiskyRepository.xml
@@ -24,6 +24,11 @@
     SELECT * FROM whisky WHERE id= #{id} AND is_deleted = FALSE
   </select>
 
+  <!--Whisky詳細検索、whiskyNameで検索-->
+  <select id="searchWhiskyByName" resultType="com.whisukiquest.whiskyquest_api.data.Whisky">
+    SELECT * FROM whisky WHERE name= #{name} AND is_deleted = FALSE
+  </select>
+
   <!--Rating情報平均検索-->
   <select id="searchAverageRating" resultType="com.whisukiquest.whiskyquest_api.domain.RatingAverage">
     SELECT whisky_id, AVG(rating) AS average_rating, COUNT(*) AS rating_count


### PR DESCRIPTION
## 実装内容
-ウイスキーIDを自動採番にしていたため、同じウイスキー名でも別IDが付与されてしまう事に気が付き
　一旦ウイスキー名で重複チェックを行い、重複がある場合はエラーを返すように実装しました。
-フロントでは、登録時エラーメッセージを表示させました。
<img width="745" height="263" alt="スクリーンショット 2025-09-21 163943" src="https://github.com/user-attachments/assets/bfa2bc6e-9f34-4d80-b79d-31f91874d6b0" />
